### PR TITLE
fix: createStitches() type

### DIFF
--- a/packages/core/types/config.d.ts
+++ b/packages/core/types/config.d.ts
@@ -4,7 +4,7 @@ import type Stitches from './stitches.js'
 /** Configuration Interface */
 declare namespace ConfigType {
 	/** Prefix interface. */
-	export type Prefix<T = ''> = T extends string ? T: string
+	export type Prefix<T = ''> = T extends string ? T : string
 
 	/** Media interface. */
 	export type Media<T = {}> = {
@@ -28,10 +28,10 @@ declare namespace ConfigType {
 		transitions?: { [token in number | string]: boolean | number | string }
 		zIndices?: { [token in number | string]: boolean | number | string }
 	} & {
-		[Scale in keyof T]: {
-			[Token in keyof T[Scale]]: T[Scale][Token] extends (boolean | number | string) ? T[Scale][Token] : (boolean | number | string)
+			[Scale in keyof T]: {
+				[Token in keyof T[Scale]]: T[Scale][Token] extends (boolean | number | string) ? T[Scale][Token] : (boolean | number | string)
+			}
 		}
-	}
 
 	/** ThemeMap interface. */
 	export type ThemeMap<T = {}> = {
@@ -205,6 +205,6 @@ export type CreateStitches = {
 			theme?: ConfigType.Theme<Theme>
 			themeMap?: ConfigType.ThemeMap<ThemeMap>
 			utils?: ConfigType.Utils<Utils>
-		}
+		}, isShadowDom?: boolean
 	): Stitches<Prefix, Media, Theme, ThemeMap, Utils>
 }

--- a/packages/react/types/config.d.ts
+++ b/packages/react/types/config.d.ts
@@ -4,7 +4,7 @@ import type Stitches from './stitches.js'
 /** Configuration Interface */
 declare namespace ConfigType {
 	/** Prefix interface. */
-	export type Prefix<T = ''> = T extends string ? T: string
+	export type Prefix<T = ''> = T extends string ? T : string
 
 	/** Media interface. */
 	export type Media<T = {}> = {
@@ -28,10 +28,10 @@ declare namespace ConfigType {
 		transitions?: { [token in number | string]: boolean | number | string }
 		zIndices?: { [token in number | string]: boolean | number | string }
 	} & {
-		[Scale in keyof T]: {
-			[Token in keyof T[Scale]]: T[Scale][Token] extends (boolean | number | string) ? T[Scale][Token] : (boolean | number | string)
+			[Scale in keyof T]: {
+				[Token in keyof T[Scale]]: T[Scale][Token] extends (boolean | number | string) ? T[Scale][Token] : (boolean | number | string)
+			}
 		}
-	}
 
 	/** ThemeMap interface. */
 	export type ThemeMap<T = {}> = {
@@ -205,6 +205,6 @@ export type CreateStitches = {
 			theme?: ConfigType.Theme<Theme>
 			themeMap?: ConfigType.ThemeMap<ThemeMap>
 			utils?: ConfigType.Utils<Utils>
-		}
+		}, isShadowDom?: boolean
 	): Stitches<Prefix, Media, Theme, ThemeMap, Utils>
 }


### PR DESCRIPTION
fixes the [type error on `createStitches()`](https://github.com/voiceflow/react-chat/pull/116) when we're passing a custom second argument `isShadowDom` (used for storybook v production theme attachment strategy)
